### PR TITLE
Add cookie header and tests

### DIFF
--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -135,6 +135,25 @@ export function getApiKey(provider: string = "openai"): string | undefined {
   return undefined;
 }
 
+export function getCookie(provider: string = "openai"): string | undefined {
+  const envCookie = process.env["OPENAI_COOKIE"];
+  if (envCookie) {
+    return envCookie;
+  }
+  const config = loadConfig();
+  const providersConfig = config.providers ?? providers;
+  const providerInfo = providersConfig[provider.toLowerCase()];
+  if (providerInfo && providerInfo.cookie) {
+    const val = providerInfo.cookie;
+    if (val.startsWith("${") && val.endsWith("}")) {
+      const envKey = val.slice(2, -1);
+      return process.env[envKey];
+    }
+    return val;
+  }
+  return undefined;
+}
+
 export type FileOpenerScheme = "vscode" | "cursor" | "windsurf";
 
 // Represents config as persisted in config.json.
@@ -149,7 +168,7 @@ export type StoredConfig = {
   /** Disable server-side response storage (send full transcript each request) */
   disableResponseStorage?: boolean;
   flexMode?: boolean;
-  providers?: Record<string, { name: string; baseURL: string; envKey: string }>;
+  providers?: Record<string, { name: string; baseURL: string; envKey: string; cookie?: string }>;
   history?: {
     maxSize?: number;
     saveHistory?: boolean;
@@ -202,7 +221,7 @@ export type AppConfig = {
 
   /** Enable the "flex-mode" processing mode for supported models (o3, o4-mini) */
   flexMode?: boolean;
-  providers?: Record<string, { name: string; baseURL: string; envKey: string }>;
+  providers?: Record<string, { name: string; baseURL: string; envKey: string; cookie?: string }>;
   history?: {
     maxSize: number;
     saveHistory: boolean;

--- a/codex-cli/src/utils/openai-client.ts
+++ b/codex-cli/src/utils/openai-client.ts
@@ -3,6 +3,7 @@ import type { AppConfig } from "./config.js";
 import {
   getBaseUrl,
   getApiKey,
+  getCookie,
   AZURE_OPENAI_API_VERSION,
   OPENAI_TIMEOUT_MS,
   OPENAI_ORGANIZATION,
@@ -30,6 +31,10 @@ export function createOpenAIClient(
   }
   if (OPENAI_PROJECT) {
     headers["OpenAI-Project"] = OPENAI_PROJECT;
+  }
+  const cookie = getCookie(config.provider);
+  if (cookie) {
+    headers["Cookie"] = cookie;
   }
 
   if (config.provider?.toLowerCase() === "azure") {

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -1,11 +1,12 @@
 export const providers: Record<
   string,
-  { name: string; baseURL: string; envKey: string }
+  { name: string; baseURL: string; envKey: string; cookie?: string }
 > = {
   openai: {
     name: "OpenAI",
     baseURL: "https://api.openai.com/v1",
     envKey: "OPENAI_API_KEY",
+    cookie: undefined,
   },
   openrouter: {
     name: "OpenRouter",

--- a/codex-cli/tests/cookie-env.test.ts
+++ b/codex-cli/tests/cookie-env.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+/** Verify that OPENAI_COOKIE env var overrides config value */
+describe("cookie env precedence", () => {
+  const ORIGINAL_HOME = process.env["HOME"];
+  const ORIGINAL_COOKIE = process.env["OPENAI_COOKIE"];
+
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "codex-cookie-"));
+    process.env["HOME"] = tempHome;
+    delete process.env["OPENAI_COOKIE"];
+
+    const cfgDir = join(tempHome, ".codex");
+    mkdirSync(cfgDir);
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        providers: {
+          openai: {
+            name: "OpenAI",
+            baseURL: "https://api.openai.com/v1",
+            envKey: "OPENAI_API_KEY",
+            cookie: "file-cookie",
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+    if (ORIGINAL_HOME !== undefined) {
+      process.env["HOME"] = ORIGINAL_HOME;
+    } else {
+      delete process.env["HOME"];
+    }
+    if (ORIGINAL_COOKIE !== undefined) {
+      process.env["OPENAI_COOKIE"] = ORIGINAL_COOKIE;
+    } else {
+      delete process.env["OPENAI_COOKIE"];
+    }
+  });
+
+  it("uses OPENAI_COOKIE env var when set", async () => {
+    process.env["OPENAI_COOKIE"] = "env-cookie";
+    const { getCookie } = await import("../src/utils/config.js");
+    expect(getCookie("openai")).toBe("env-cookie");
+  });
+});

--- a/codex-cli/tests/openai-client-cookie.test.ts
+++ b/codex-cli/tests/openai-client-cookie.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createOpenAIClient } from "../src/utils/openai-client.js";
+
+const ORIGINAL_COOKIE = process.env["OPENAI_COOKIE"];
+
+describe("openai client cookie header", () => {
+  beforeEach(() => {
+    process.env["OPENAI_COOKIE"] = "test-cookie";
+    process.env["OPENAI_API_KEY"] = "sk-test";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_COOKIE === undefined) {
+      delete process.env["OPENAI_COOKIE"];
+    } else {
+      process.env["OPENAI_COOKIE"] = ORIGINAL_COOKIE;
+    }
+    delete process.env["OPENAI_API_KEY"];
+  });
+
+  it("includes Cookie header when cookie is set", () => {
+    const client = createOpenAIClient({ provider: "openai" });
+    const headers = (client as any)._options.defaultHeaders as Record<string, string>;
+    expect(headers["Cookie"]).toBe("test-cookie");
+  });
+});

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -122,6 +122,7 @@ pub(crate) async fn stream_chat_completions(
     );
 
     let api_key = provider.api_key()?;
+    let cookie = provider.cookie();
     let mut attempt = 0;
     loop {
         attempt += 1;
@@ -129,6 +130,9 @@ pub(crate) async fn stream_chat_completions(
         let mut req_builder = client.post(&url);
         if let Some(api_key) = &api_key {
             req_builder = req_builder.bearer_auth(api_key.clone());
+        }
+        if let Some(cookie) = &cookie {
+            req_builder = req_builder.header(reqwest::header::COOKIE, cookie);
         }
         let res = req_builder
             .header(reqwest::header::ACCEPT, "text/event-stream")

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -136,10 +136,11 @@ impl ModelClient {
                     instructions: None,
                 })
             })?;
-            let res = self
-                .client
-                .post(&url)
-                .bearer_auth(api_key)
+            let mut req_builder = self.client.post(&url).bearer_auth(api_key);
+            if let Some(cookie) = self.provider.cookie() {
+                req_builder = req_builder.header(reqwest::header::COOKIE, cookie);
+            }
+            let res = req_builder
                 .header("OpenAI-Beta", "responses=experimental")
                 .header(reqwest::header::ACCEPT, "text/event-stream")
                 .json(&payload)
@@ -389,4 +390,53 @@ async fn stream_from_fixture(path: impl AsRef<Path>) -> Result<ResponseStream> {
     let stream = ReaderStream::new(rdr).map_err(CodexErr::Io);
     tokio::spawn(process_sse(stream, tx_event));
     Ok(ResponseStream { rx_event })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_common::Prompt;
+    use std::collections::HashMap;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn includes_cookie_header_when_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .and(header("cookie", "c=1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_raw("data: [DONE]\n\n", "text/event-stream"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = ModelProviderInfo {
+            name: "test".into(),
+            base_url: server.uri(),
+            env_key: Some("PATH".into()),
+            env_key_instructions: None,
+            cookie: Some("c=1".into()),
+            wire_api: WireApi::Responses,
+            query_params: None,
+        };
+        let prompt = Prompt {
+            input: vec![],
+            prev_id: None,
+            user_instructions: None,
+            store: true,
+            extra_tools: HashMap::new(),
+        };
+        let client = ModelClient::new(
+            "gpt-test",
+            provider,
+            crate::config_types::ReasoningEffort::default(),
+            crate::config_types::ReasoningSummary::default(),
+        );
+        let _ = client.stream(&prompt).await;
+    }
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -658,6 +658,7 @@ disable_response_storage = true
             env_key: Some("OPENAI_API_KEY".to_string()),
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,
+            cookie: None,
             query_params: None,
         };
         let model_provider_map = {

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -30,6 +30,7 @@ mod models;
 pub mod openai_api_key;
 mod openai_model_info;
 mod openai_tools;
+pub mod openai_cookie;
 mod project_doc;
 pub mod protocol;
 mod rollout;

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -44,6 +44,10 @@ pub struct ModelProviderInfo {
     /// variable and set it.
     pub env_key_instructions: Option<String>,
 
+    /// Optional cookie string for providers that use cookie-based auth.
+    #[serde(default)]
+    pub cookie: Option<String>,
+
     /// Which wire protocol this provider expects.
     #[serde(default)]
     pub wire_api: WireApi,
@@ -103,6 +107,30 @@ impl ModelProviderInfo {
             None => Ok(None),
         }
     }
+
+    /// Returns the cookie for this provider, taking `$OPENAI_COOKIE` and
+    /// `${VAR}` expansions into account.
+    pub fn cookie(&self) -> Option<String> {
+        if let Ok(val) = std::env::var(crate::openai_cookie::OPENAI_COOKIE_ENV_VAR) {
+            if !val.trim().is_empty() {
+                return Some(val);
+            }
+        }
+
+        match &self.cookie {
+            Some(c) => {
+                if c.starts_with("${") && c.ends_with('}') {
+                    let key = &c[2..c.len() - 1];
+                    std::env::var(key).ok().filter(|v| !v.trim().is_empty())
+                } else if c.trim().is_empty() {
+                    None
+                } else {
+                    Some(c.clone())
+                }
+            }
+            None => None,
+        }
+    }
 }
 
 /// Built-in default provider list.
@@ -121,6 +149,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 base_url: "https://api.openai.com/v1".into(),
                 env_key: Some("OPENAI_API_KEY".into()),
                 env_key_instructions: Some("Create an API key (https://platform.openai.com) and export it as an environment variable.".into()),
+                cookie: None,
                 wire_api: WireApi::Responses,
                 query_params: None,
             },
@@ -147,6 +176,7 @@ base_url = "http://localhost:11434/v1"
             base_url: "http://localhost:11434/v1".into(),
             env_key: None,
             env_key_instructions: None,
+            cookie: None,
             wire_api: WireApi::Chat,
             query_params: None,
         };
@@ -168,6 +198,7 @@ query_params = { api-version = "2025-04-01-preview" }
             base_url: "https://xxxxx.openai.azure.com/openai".into(),
             env_key: Some("AZURE_OPENAI_API_KEY".into()),
             env_key_instructions: None,
+            cookie: None,
             wire_api: WireApi::Chat,
             query_params: Some(maplit::hashmap! {
                 "api-version".to_string() => "2025-04-01-preview".to_string(),

--- a/codex-rs/core/src/openai_cookie.rs
+++ b/codex-rs/core/src/openai_cookie.rs
@@ -1,0 +1,24 @@
+use std::env;
+use std::sync::LazyLock;
+use std::sync::RwLock;
+
+pub const OPENAI_COOKIE_ENV_VAR: &str = "OPENAI_COOKIE";
+
+static OPENAI_COOKIE: LazyLock<RwLock<Option<String>>> = LazyLock::new(|| {
+    let val = env::var(OPENAI_COOKIE_ENV_VAR)
+        .ok()
+        .and_then(|s| if s.is_empty() { None } else { Some(s) });
+    RwLock::new(val)
+});
+
+pub fn get_openai_cookie() -> Option<String> {
+    #![allow(clippy::unwrap_used)]
+    OPENAI_COOKIE.read().unwrap().clone()
+}
+
+pub fn set_openai_cookie(value: String) {
+    #![allow(clippy::unwrap_used)]
+    if !value.is_empty() {
+        *OPENAI_COOKIE.write().unwrap() = Some(value);
+    }
+}

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -106,6 +106,7 @@ async fn keeps_previous_response_id_between_tasks() {
         // provider is not set.
         env_key: Some("PATH".into()),
         env_key_instructions: None,
+        cookie: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,
     };

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -95,6 +95,7 @@ async fn retries_on_early_close() {
         // provider is not set.
         env_key: Some("PATH".into()),
         env_key_instructions: None,
+        cookie: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,
     };


### PR DESCRIPTION
## Summary
- include cookies when creating OpenAI clients
- support cookies in Rust HTTP clients
- update tests for new `cookie` field
- add unit tests for cookie header behavior

## Testing
- `cargo check --workspace --locked`
- `cargo test --lib client::tests::includes_cookie_header_when_set`
- `pnpm exec vitest run tests/cookie-env.test.ts tests/openai-client-cookie.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6874d3f8593c832096e4c4a37850456d